### PR TITLE
Remove redundant currentNode field

### DIFF
--- a/src/models/conversationModel.ts
+++ b/src/models/conversationModel.ts
@@ -81,7 +81,6 @@ const ConversationSchema = new Schema<IConversation>({
     messages: [messageSchema],
     currentNode: { type: String, default: 'entry' },
     conversationState: {
-        currentNode: { type: String, default: 'entry' },
         hasMetBefore: { type: Boolean, default: false },
         engagementLevel: { type: Number, default: 0 },
         revealMade: { type: Boolean, default: false },

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -82,7 +82,6 @@ export enum ConversationNodeType {
 }
 
 export interface ConversationState {
-    currentNode: ConversationNodeType;
     hasMetBefore: boolean;
     engagementLevel: number;
     revealMade: boolean;


### PR DESCRIPTION
## Summary
- stop persisting `conversationState.currentNode` in the conversation model
- update `ConversationState` type accordingly

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685f171d7418832798990841f0f4a258